### PR TITLE
Makes the `timetagger setup` more universal adding a fallback editor.

### DIFF
--- a/timetagger_cli/utils.py
+++ b/timetagger_cli/utils.py
@@ -29,7 +29,10 @@ def open_with_os_default(path):
     elif sys.platform.startswith("linux"):
         # xdg-open is available on all Freedesktop.org compliant distros
         # http://superuser.com/questions/38984/linux-equivalent-command-for-open-command-on-mac-windows
-        subprocess.call(("xdg-open", path))
+        try:
+            subprocess.call(("xdg-open", path))
+        except FileNotFoundError:
+            subprocess.call(("vi", path))
     else:
         raise RuntimeError(f"Don't know how to open {path}")
 


### PR DESCRIPTION
Add `vi` as a fallback in case `xdg-open` is not installed, as it happens in Ubuntu on WSL.

Solves #8 