### PR TITLE
Check for a default editor to open the config file

### DIFF
--- a/timetagger_cli/utils.py
+++ b/timetagger_cli/utils.py
@@ -32,7 +32,7 @@ def open_with_os_default(path):
         try:
             subprocess.call(("xdg-open", path))
         except FileNotFoundError:
-            subprocess.call(("vi", path))
+            subprocess.call((os.getenv('EDITOR', 'vi'), path))
     else:
         raise RuntimeError(f"Don't know how to open {path}")
 


### PR DESCRIPTION
Instead of opening the config file in `vi` when `xdg-open` doesn't work, we can check for if the user set another editor as preferred default with the `EDITOR` environment variable.