### PR TITLE
Updated resume. Fixes #15

### DIFF
--- a/timetagger_cli/core.py
+++ b/timetagger_cli/core.py
@@ -177,8 +177,8 @@ def resume(selected=None):
         print("No records within the last week.")
         return
 
-    # Sort records by server time to get same order as on server
-    filtered_records.sort(key=lambda r: r["st"])
+    # Sort records by time
+    filtered_records.sort(key=lambda r: r["t2"])
 
     # Get last 10 records
     if len(filtered_records) > 10:

--- a/timetagger_cli/core.py
+++ b/timetagger_cli/core.py
@@ -184,7 +184,7 @@ def resume(selected=None):
     if len(filtered_records) > 10:
         filtered_records = filtered_records[-10:]
 
-    if isinstance(selected, type(None)):
+    if selected is None:
         print("Which record would you like to resume? [1]")
         for i in range(len(filtered_records)):
             number_string = f"[{len(filtered_records)-i}]"


### PR DESCRIPTION
The `resume` function is updated with optional index argument and selector.  
Search for previous records have been limited to the last week, as that seems a reasonable timeframe. Some of the responses/error-messages and formatting could be replaced with something else.  
Tested to make sure it is still not possible to start an already running record.  
  
As mentioned in title this should fix #15 