### PR TITLE
Add support for HTTP Basic authentication

### DIFF
--- a/timetagger_cli/core.py
+++ b/timetagger_cli/core.py
@@ -28,8 +28,13 @@ def request(method, path, body=None):
     if not token:
         raise RuntimeError("api_token not set, run 'timetagger setup' first.")
 
+    if "auth_username" in config.keys() and "auth_password" in config.keys():
+        auth = (config["auth_username"], config["auth_password"])
+    else:
+        auth = None
+
     headers = {"authtoken": token}
-    response = requests.request(method.upper(), url, json=body, headers=headers)
+    response = requests.request(method.upper(), url, json=body, headers=headers, auth=auth)
 
     if response.status_code == 200:
         return response.json()


### PR DESCRIPTION
We run timetagger locally hosted with LDAP authentication. This produces the (probably rather unusual) requirement to authenticate to the reverse-proxy using the LDAP credentials before we can access the API.
For this I added support for that using two new configuration options `auth_username` and `auth_password`.

This code currently works for me.

However, I'm unsure where to advertise that feature (i.e. whether to put it in the sample configuration).
Also, I don't think it should be too obvious, because we probably don't want people to configure username/password unless they really need that (after all, you're putting a cleartext password into the configuration)
Maybe we could emit a helpful error when we get an HTTP 401 and not mention it otherwise?

Another thing I noticed is, that maybe I should add a check that either both or none of the parameters are set when we load the config.

Any guidance, hints and suggestions are very welcome!
