### PR TITLE
Configure SSL certificate

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ def test_load_config():
     assert isinstance(d, dict)
     assert "api_url" in d
     assert "api_token" in d
+    assert "ssl_verify" in d
 
 
 def test_load_config_fail():
@@ -61,6 +62,12 @@ def test_load_config_fail():
         f.write(text.encode())
     with raises(RuntimeError):
         config.load_config()
+
+    # File without ssl_verify
+    with open(filename, "wb") as f:
+        text = ori_text.replace("ssl_verify", "xxx_verify")
+        f.write(text.encode())
+    assert config.load_config()
 
     # But ok to add other stuff ...
     with open(filename, "wb") as f:

--- a/timetagger_cli/config.py
+++ b/timetagger_cli/config.py
@@ -6,7 +6,7 @@ import toml
 from .utils import user_config_dir
 
 initial_config_text = """
-# This is the TimeTagger CLI configurationm, in toml format.
+# This is the TimeTagger CLI configuration, in toml format.
 # Clear or remove this file to reset to factory defaults.
 
 # Set the base API URL, for example:

--- a/timetagger_cli/config.py
+++ b/timetagger_cli/config.py
@@ -17,6 +17,13 @@ api_url = "https://timetagger.app/api/v2/"
 # Set your API token.
 # Go to the account page, copy the token, paste it here (between the quotes).
 api_token = ""
+
+# If you're self-hosting, you might need to set your own self-signed certificate or disable the verification of SSL certificate.
+# Disabling the certificate verification is a potentially risky action that might expose your application to attacks.
+# You can set the path to a self signed certificate for verification and validation:
+# - ssl_verify = "path/to/certificate"
+# For more information, visit: https://letsencrypt.org/docs/certificates-for-localhost/
+ssl_verify = true
 """.lstrip().replace(
     "\r\n", "\n"
 )
@@ -45,6 +52,8 @@ def load_config():
         )
     if "api_token" not in config:
         raise RuntimeError("No api_token set in config. Run 'timetagger setup' to fix.")
+    if "ssl_verify" not in config:
+        config |= {"ssl_verify": True}
     return config
 
 

--- a/timetagger_cli/config.py
+++ b/timetagger_cli/config.py
@@ -71,6 +71,8 @@ def prepare_config_file():
         else:
             with open(filename, "wb") as f:
                 f.write(initial_config_text.encode())
+        # Config file contains user secret so it should not be readable to others
+        os.chmod(filename, 0o640)
     except Exception as err:  # pragma: no cover
         print(f"Could not prepare config file: {err}")
 

--- a/timetagger_cli/core.py
+++ b/timetagger_cli/core.py
@@ -25,11 +25,12 @@ def request(method, path, body=None):
     config = load_config()
     url = config["api_url"].rstrip("/") + "/" + path.lstrip("/")
     token = config["api_token"].strip()
+    ssl_verify = config["ssl_verify"]
     if not token:
         raise RuntimeError("api_token not set, run 'timetagger setup' first.")
 
     headers = {"authtoken": token}
-    response = requests.request(method.upper(), url, json=body, headers=headers)
+    response = requests.request(method.upper(), url, json=body, headers=headers, verify=ssl_verify)
 
     if response.status_code == 200:
         return response.json()

--- a/timetagger_cli/core.py
+++ b/timetagger_cli/core.py
@@ -1,6 +1,7 @@
 import time
 import datetime
 import webbrowser
+import os
 
 import requests
 
@@ -88,6 +89,8 @@ def setup(args=None):
     filename = prepare_config_file()
     print("Config file: " + filename)
     print("Will now (try to) open the config file. Just edit and save the file.")
+    # Config file contains user secret so it should not be readable to others
+    os.chmod(filename, 0o640)
     open_with_os_default(filename)
 
 

--- a/timetagger_cli/core.py
+++ b/timetagger_cli/core.py
@@ -30,7 +30,9 @@ def request(method, path, body=None):
         raise RuntimeError("api_token not set, run 'timetagger setup' first.")
 
     headers = {"authtoken": token}
-    response = requests.request(method.upper(), url, json=body, headers=headers, verify=ssl_verify)
+    response = requests.request(
+        method.upper(), url, json=body, headers=headers, verify=ssl_verify
+    )
 
     if response.status_code == 200:
         return response.json()

--- a/timetagger_cli/core.py
+++ b/timetagger_cli/core.py
@@ -89,8 +89,6 @@ def setup(args=None):
     filename = prepare_config_file()
     print("Config file: " + filename)
     print("Will now (try to) open the config file. Just edit and save the file.")
-    # Config file contains user secret so it should not be readable to others
-    os.chmod(filename, 0o640)
     open_with_os_default(filename)
 
 


### PR DESCRIPTION
Add option for the user to configure SSL certificate and either set one that's self-signed or ignore it completely when creating the request. Might be useful for people self-hosting inside an internal network that can't issue a certificate for validity and have one that of their own that they trust.

Edit: No idea why but all my work got PRd at once.

Changes made also include fix of #23, the config file contains a private information thus should be unreadable for others, and a typo fix in the config file's comment.